### PR TITLE
fix: file write lock issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+gitconfig_backup

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +68,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "git2"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +108,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +135,15 @@ checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -90,10 +159,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.13.2+1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "log"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -103,6 +246,18 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "strsim"
@@ -116,6 +271,8 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "colored",
+ "git2",
+ "home",
 ]
 
 [[package]]
@@ -132,6 +289,54 @@ name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2021"
 [dependencies]
 clap = { version = "3.1.6", features = ["cargo"] }
 colored = "2"
+git2 = "0.14"
+home = "0.5.3"

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,115 @@
+use git2::Config;
+use home::home_dir;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+const USER_EMAIL: &str = "user.email";
+const USER_NAME: &str = "user.name";
+
+pub struct Git {
+    config: Config,
+    config_path: PathBuf,
+    user_name: String,
+    user_email: String,
+}
+
+impl Git {
+    /// Creates a new instance of `Git` and loads the global config for Git.
+    ///
+    /// As a side effect, a backup of the global config is created using
+    /// `Git::backup`.
+    pub fn new() -> Self {
+        let mut config_path = home_dir().unwrap();
+        config_path.push(".gitconfig");
+        Git::backup(&config_path);
+
+        let config = Config::open(&config_path).unwrap();
+        let user_name = config.get_string(USER_NAME).unwrap().to_string();
+        let user_email = config.get_string(USER_EMAIL).unwrap().to_string();
+
+        Self {
+            config,
+            config_path,
+            user_name,
+            user_email,
+        }
+    }
+
+    /// Retrieves the global config user.name and stores it as part of the
+    /// `Git` config state
+    #[inline]
+    pub fn get_user_name(&mut self) -> String {
+        let user_name = self.config.get_string(USER_NAME).unwrap().to_string();
+
+        self.user_name = user_name.clone();
+        user_name
+    }
+
+    /// Retrieves the global config user.email and stores it as part of the
+    /// `Git` config state
+    #[inline]
+    pub fn get_user_email(&mut self) -> String {
+        let user_email = self.config.get_string(USER_EMAIL).unwrap().to_string();
+
+        self.user_email = user_email.clone();
+        user_email
+    }
+
+    /// Sets the global config user.name and stores it as part of the `Git`
+    /// config state
+    #[inline]
+    pub fn set_user_name(&mut self, name: &str) {
+        self.config.set_str("user.name", name).unwrap();
+        self.user_name = name.to_string();
+    }
+
+    /// Sets the global config user.email and stores it as part of the `Git`
+    /// config state
+    #[inline]
+    pub fn set_user_email(&mut self, email: &str) {
+        self.config.set_str("user.email", email).unwrap();
+        self.user_email = email.to_string();
+    }
+
+    /// Copies the current `$HOME/.gitconfig` file into
+    /// `$PWD/tmp/gitconfig_backup`
+    ///
+    /// This file then can be used to reset changes applied to the `.gitconfig`
+    /// file when first running git operations.
+    fn backup<P>(config_path: P)
+    where
+        P: AsRef<Path>,
+    {
+        let mut cwd = env::current_dir().unwrap();
+        cwd.push("tmp");
+        cwd.push("gitconfig_backup");
+
+        fs::copy(&config_path, &cwd).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Git;
+
+    #[test]
+    fn sets_git_global_config() {
+        let mut git = Git::new();
+        let current_user_name = git.get_user_name();
+        let current_user_email = git.get_user_email();
+
+        git.set_user_name("Hello World");
+        git.set_user_email("hello@world.com");
+
+        assert_eq!(git.user_name, "Hello World");
+        assert_eq!(git.user_email, "hello@world.com");
+
+        git.set_user_name(&current_user_name);
+        git.set_user_email(&current_user_email);
+
+        assert_eq!(git.get_user_name(), current_user_name);
+        assert_eq!(git.get_user_email(), current_user_email);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod git;
 mod log;
 mod workspace;
 
@@ -16,10 +17,12 @@ fn main() -> IoResult<()> {
         .get_matches();
 
     if program.is_present("env") {
+        let mut workspace = Workspace::new();
+
         match program.value_of("env") {
             Some(value) => match value {
-                "personal" => Workspace::create_config(Env::Personal)?,
-                "work" => Workspace::create_config(Env::Work)?,
+                "personal" => workspace.create_config(Env::Personal)?,
+                "work" => workspace.create_config(Env::Work)?,
                 _ => Log::error("Not valid workspace"),
             },
             None => Log::error("Please, provide an valid option"),


### PR DESCRIPTION
Currently two commands are spawned simultaneously in separated threads.
This causes a lock issue with the file being written due the need of using a
`thread::sleep`.

This PR suggests an approach were `libgit2` is used, and the need of spawning
commands is no longer required.

With LibGit2 we open and parse the configuration on `$HOME/.gitconfig` and
read/write to it.

A backup of the file on first run is made whenever a `Git` instance is created,
this way we can get back to the original state if something comes wrong.

This PR still lacks lots of error handling, `unwrap` is used to prototype the approach
but some cleanup and error handling would be great after this approach gets approved.